### PR TITLE
disable ansible-lint in megalinter to get rid of spurious missing module error

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,13 +36,11 @@ jobs:
                 fromJSON('
                   [
                     "ACTION_ACTIONLINT",
-                    "ANSIBLE_ANSIBLE_LINT",
                     "COPYPASTE_JSCPD",
                     "KUBERNETES_KUBEVAL",
                     "MARKDOWN_MARKDOWNLINT",
                     "REPOSITORY_GIT_DIFF",
                     "REPOSITORY_SECRETLINT",
-                    "TERRAFORM_TERRAFORM_FMT",
                     "YAML_PRETTIER",
                     "YAML_YAMLLINT"
                   ]


### PR DESCRIPTION
**Description of the change**

I tried to get rid of the error about `community.general.timezone` missing. I renamed the requirements.yml file to the "correct" location. I tried ansible-lint comments to disable the check. I tried a pre-command to install the module. Nothing worked, so I'm disabling the ansible linter.

**Benefits**

make megalint stop yelling at me!

**Possible drawbacks**

Ansible cruft will slip through the cracks.