### PR TITLE
chore: clean up ingresses

### DIFF
--- a/kubernetes/main/apps/dbms/pgadmin/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dbms/pgadmin/app/helmrelease.yaml
@@ -36,13 +36,10 @@ spec:
         hajimari.io/appName: "Postgres Admin"
         hajimari.io/icon: simple-icons:postgresql
       hosts:
-        - host: &host pgadmin.${CLUSTER_DOMAIN}
+        - host: pgadmin.${CLUSTER_DOMAIN}
           paths:
             - path: /
               pathType: Prefix
-      tls:
-        - hosts:
-            - *host
     networkPolicy:
       enabled: false
     persistentVolume:

--- a/kubernetes/main/apps/default/excalidraw/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/excalidraw/app/helmrelease.yaml
@@ -66,11 +66,9 @@ spec:
           external-dns.alpha.kubernetes.io/target: external.${CLUSTER_DOMAIN}
           hajimari.io/icon: mdi:draw-pen
         hosts:
-          - host: &host draw.${CLUSTER_DOMAIN}
+          - host: draw.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]

--- a/kubernetes/main/apps/default/hajimari/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/hajimari/app/helmrelease.yaml
@@ -82,13 +82,10 @@ spec:
         annotations:
           hajimari.io/enable: "false"
         hosts:
-          - host: &host "hajimari.${CLUSTER_DOMAIN}"
+          - host: hajimari.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 pathType: Prefix
-        tls:
-          - hosts:
-              - *host
     podAnnotations:
       configmap.reloader.stakater.com/reload: "hajimari-settings"
     persistence:

--- a/kubernetes/main/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/homepage/app/helmrelease.yaml
@@ -61,15 +61,13 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host home.${CLUSTER_DOMAIN}
+          - host: home.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 pathType: Prefix
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     serviceAccount:
       create: true
     persistence:

--- a/kubernetes/main/apps/default/kubernetes-schemas/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/kubernetes-schemas/app/helmrelease.yaml
@@ -72,14 +72,12 @@ spec:
           external-dns.alpha.kubernetes.io/target: external.${CLUSTER_DOMAIN}
           hajimari.io/icon: mdi:code-json
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       tmp:
         type: emptyDir

--- a/kubernetes/main/apps/default/memos/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/memos/app/helmrelease.yaml
@@ -77,14 +77,12 @@ spec:
         enabled: true
         className: internal
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         existingClaim: ${VOLSYNC_CLAIM}

--- a/kubernetes/main/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/miniflux/app/helmrelease.yaml
@@ -112,11 +112,9 @@ spec:
         annotations:
           hajimari.io/icon: mdi:rss
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]

--- a/kubernetes/main/apps/default/populator-test/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/populator-test/app/helmrelease.yaml
@@ -77,14 +77,11 @@ spec:
         enabled: true
         className: internal
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: main
-        tls:
-          - hosts:
-              - *host
     persistence:
       data:
         enabled: true

--- a/kubernetes/main/apps/flux-system/addons/app/webhooks/github/ingress.yaml
+++ b/kubernetes/main/apps/flux-system/addons/app/webhooks/github/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: external
   rules:
-    - host: &host flux-receiver.${CLUSTER_DOMAIN}
+    - host: flux-receiver.${CLUSTER_DOMAIN}
       http:
         paths:
           - path: /hook/
@@ -19,5 +19,3 @@ spec:
                 name: webhook-receiver
                 port:
                   number: 80
-  tls:
-    - hosts: [*host]

--- a/kubernetes/main/apps/flux-system/capacitor/app/helmrelease.yaml
+++ b/kubernetes/main/apps/flux-system/capacitor/app/helmrelease.yaml
@@ -57,11 +57,9 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host capacitor.${CLUSTER_DOMAIN}
+          - host: capacitor.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]

--- a/kubernetes/main/apps/home/node-red/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home/node-red/app/helmrelease.yaml
@@ -69,14 +69,12 @@ spec:
         annotations:
           hajimari.io/icon: mdi:sitemap
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         existingClaim: ${VOLSYNC_CLAIM}

--- a/kubernetes/main/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -110,14 +110,12 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host "zigbee.${CLUSTER_DOMAIN}"
+          - host: "zigbee.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         existingClaim: zigbee2mqtt

--- a/kubernetes/main/apps/joomla/rtr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/joomla/rtr/app/helmrelease.yaml
@@ -55,14 +55,12 @@ spec:
         annotations:
           hajimari.io/appName: "Ride To Remeber"
         hosts:
-          - host: &host "ridetoremember.${CLUSTER_DOMAIN}"
+          - host: ridetoremember.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         existingClaim: rtr-data-v1

--- a/kubernetes/main/apps/media/calibre-web/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/calibre-web/app/helmrelease.yaml
@@ -74,14 +74,12 @@ spec:
           gethomepage.dev/name: Calibre
           gethomepage.dev/icon: calibre.png
         hosts:
-          - host: &host ebooks.${CLUSTER_DOMAIN}
+          - host: ebooks.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       cache:
         type: emptyDir

--- a/kubernetes/main/apps/media/media-browser/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/media-browser/app/helmrelease.yaml
@@ -78,14 +78,12 @@ spec:
         annotations:
           hajimari.io/icon: mdi:folder-play-outline
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         type: persistentVolumeClaim

--- a/kubernetes/main/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/tautulli/app/helmrelease.yaml
@@ -95,14 +95,12 @@ spec:
           gethomepage.dev/widget.url: http://tautulli.media:8181/plexpy
           gethomepage.dev/widget.key: "{{ `{{HOMEPAGE_VAR_TAUTULLI_TOKEN}}` }}"
         hosts:
-          - host: &host tautulli.${CLUSTER_DOMAIN}
+          - host: tautulli.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         existingClaim: ${VOLSYNC_CLAIM}

--- a/kubernetes/main/apps/monitoring/apprise/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/apprise/app/helmrelease.yaml
@@ -53,14 +53,12 @@ spec:
         annotations:
           hajimari.io/icon: bell-cog
         hosts:
-          - host: &host "apprise.${CLUSTER_DOMAIN}"
+          - host: apprise.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     # TODO: volsync
     persistence:
       config:

--- a/kubernetes/main/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
@@ -57,13 +57,10 @@ spec:
       annotations:
         hajimari.io/enable: "false"
       hosts:
-        - host: &host blackbox.${CLUSTER_DOMAIN}
+        - host: blackbox.${CLUSTER_DOMAIN}
           paths:
             - path: /
               pathType: Prefix
-      tls:
-        - hosts:
-            - *host
     podAnnotations:
       reloader.stakater.com/auto: "true"
     resources:

--- a/kubernetes/main/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/gatus/app/helmrelease.yaml
@@ -126,14 +126,12 @@ spec:
           gethomepage.dev/name: Gatus
           gethomepage.dev/icon: gatus.png
         hosts:
-          - host: &host status.${CLUSTER_DOMAIN}
+          - host: status.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     serviceAccount:
       create: true
       name: gatus

--- a/kubernetes/main/apps/monitoring/goldpinger/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/goldpinger/app/helmrelease.yaml
@@ -36,13 +36,10 @@ spec:
       annotations:
         hajimari.io/icon: "table-tennis"
       hosts:
-        - host: &host goldpinger.${CLUSTER_DOMAIN}
+        - host: goldpinger.${CLUSTER_DOMAIN}
           paths:
             - path: /
               pathType: Prefix
-      tls:
-        - hosts:
-            - *host
     resources:
       requests:
         cpu: 15m

--- a/kubernetes/main/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/grafana/app/helmrelease.yaml
@@ -407,9 +407,7 @@ spec:
         hajimari.io/appName: "grafana"
         hajimari.io/icon: simple-icons:grafana
       hosts:
-        - &host grafana.${CLUSTER_DOMAIN}
-      tls:
-        - hosts: [*host]
+        - grafana.${CLUSTER_DOMAIN}
     imageRenderer:
       enabled: true
       image:

--- a/kubernetes/main/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -87,14 +87,12 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/target: external.${CLUSTER_DOMAIN}
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config-file:
         type: configMap

--- a/kubernetes/main/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -42,9 +42,7 @@ spec:
           hajimari.io/appName: "Alert Manager"
           hajimari.io/icon: mdi:alert-decagram-outline
         hosts:
-          - &host alertmanager.${CLUSTER_DOMAIN}
-        tls:
-          - hosts: [*host]
+          - alertmanager.${CLUSTER_DOMAIN}
       alertmanagerSpec:
         replicas: 2
         useExistingSecret: true
@@ -162,9 +160,7 @@ spec:
           gethomepage.dev/widget.url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
         pathType: Prefix
         hosts:
-          - &host prometheus.${CLUSTER_DOMAIN}
-        tls:
-          - hosts: [*host]
+          - prometheus.${CLUSTER_DOMAIN}
       thanosService:
         enabled: true
       thanosServiceMonitor:

--- a/kubernetes/main/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/loki/app/helmrelease.yaml
@@ -143,12 +143,10 @@ spec:
         annotations:
           hajimari.io/enable: "false"
         hosts:
-          - host: &host loki.${CLUSTER_DOMAIN}
+          - host: loki.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 pathType: Prefix
-        tls:
-          - hosts: [*host]
       resources:
         requests:
           cpu: 50m

--- a/kubernetes/main/apps/monitoring/smokeping/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/smokeping/app/helmrelease.yaml
@@ -81,14 +81,12 @@ spec:
         annotations:
           hajimari.io/icon: mdi:table-tennis
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         existingClaim: smokeping-config-v1

--- a/kubernetes/main/apps/monitoring/sr505n-cache/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/sr505n-cache/app/helmrelease.yaml
@@ -80,14 +80,12 @@ spec:
         annotations:
           hajimari.io/enable: "false"
         hosts:
-          - host: &host "sr505n.${CLUSTER_DOMAIN}"
+          - host: sr505n.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/main/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/thanos/app/helmrelease.yaml
@@ -90,9 +90,7 @@ spec:
         enabled: true
         ingressClassName: internal
         hosts:
-          - &host thanos.${CLUSTER_DOMAIN}
-        tls:
-          - hosts: [*host]
+          - thanos.${CLUSTER_DOMAIN}
       podAnnotations: &podAnnotations
         configmap.reloader.stakater.com/reload: *configMap
     rule:

--- a/kubernetes/main/apps/network/external-services/hass.yaml
+++ b/kubernetes/main/apps/network/external-services/hass.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   ingressClassName: external
   rules:
-    - host: &host ha.${CLUSTER_DOMAIN}
+    - host: ha.${CLUSTER_DOMAIN}
       http:
         paths:
           - path: /
@@ -41,6 +41,3 @@ spec:
                 name: *app
                 port:
                   number: 8123
-  tls:
-    - hosts:
-        - *host

--- a/kubernetes/main/apps/network/omada-controller/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/omada-controller/app/helmrelease.yaml
@@ -143,14 +143,12 @@ spec:
           nginx.ingress.kubernetes.io/proxy-redirect-from: "~https://(.+):8043/(.+)/login$"
           nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$1/$2/login"
         hosts:
-          - host: &host omada.${CLUSTER_DOMAIN}
+          - host: omada.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         existingClaim: ${VOLSYNC_CLAIM}

--- a/kubernetes/main/apps/network/speedtest/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/speedtest/app/helmrelease.yaml
@@ -74,14 +74,12 @@ spec:
           external-dns.alpha.kubernetes.io/target: external.${CLUSTER_DOMAIN}
           hajimari.io/icon: mdi:speedometer
         hosts:
-          - host: &host speedtest.${CLUSTER_DOMAIN}
+          - host: speedtest.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       init:
         type: configMap

--- a/kubernetes/main/apps/network/web-static/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/web-static/app/helmrelease.yaml
@@ -68,14 +68,12 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host "www.${CLUSTER_DOMAIN}"
+          - host: www.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       public:
         type: secret

--- a/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -39,10 +39,8 @@ spec:
           hajimari.io/appName: "Rook"
           hajimari.io/icon: mdi:chess-rook
         host:
-          name: &host rook.${CLUSTER_DOMAIN}
+          name: rook.${CLUSTER_DOMAIN}
           path: /
-        tls:
-          - hosts: [*host]
     toolbox:
       enabled: true
     configOverride: |
@@ -313,8 +311,5 @@ spec:
           enabled: true
           ingressClassName: internal
           host:
-            name: &host objects.${CLUSTER_DOMAIN}
+            name: objects.${CLUSTER_DOMAIN}
             path: /
-          tls:
-            - hosts:
-                - *host

--- a/kubernetes/main/apps/security/authelia/app/helmrelease.yaml
+++ b/kubernetes/main/apps/security/authelia/app/helmrelease.yaml
@@ -117,14 +117,12 @@ spec:
             add_header X-Frame-Options "SAMEORIGIN";
             add_header X-XSS-Protection "1; mode=block";
         hosts:
-          - host: &host auth.${CLUSTER_DOMAIN}
+          - host: auth.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         type: configMap

--- a/kubernetes/main/apps/security/dmarc-report/app/helmrelease.yaml
+++ b/kubernetes/main/apps/security/dmarc-report/app/helmrelease.yaml
@@ -61,14 +61,12 @@ spec:
         annotations:
           hajimari.io/icon: mdi:email
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/main/apps/security/lldap/app/helmrelease.yaml
+++ b/kubernetes/main/apps/security/lldap/app/helmrelease.yaml
@@ -81,14 +81,12 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/main/apps/storage/minio/app/helmrelease.yaml
+++ b/kubernetes/main/apps/storage/minio/app/helmrelease.yaml
@@ -101,14 +101,12 @@ spec:
         annotations:
           hajimari.io/icon: mdi:pail
         hosts:
-          - host: &console-host "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
+          - host: "{{ .Release.Name }}.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*console-host]
       s3:
         className: internal
         annotations:
@@ -119,14 +117,12 @@ spec:
           nginx.ingress.kubernetes.io/configuration-snippet: |
             chunked_transfer_encoding off;
         hosts:
-          - host: &api-host s3.${CLUSTER_DOMAIN}
+          - host: s3.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: api
-        tls:
-          - hosts: [*api-host]
     persistence:
       data:
         type: nfs

--- a/kubernetes/main/apps/storage/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/main/apps/storage/nextcloud/app/helmrelease.yaml
@@ -111,9 +111,6 @@ spec:
           }
       path: /
       pathType: Prefix
-      tls:
-        - hosts:
-            - *host
     persistence:
       enabled: true
       existingClaim: ${VOLSYNC_CLAIM}

--- a/kubernetes/main/apps/storage/ocis/app/helmrelease.yaml
+++ b/kubernetes/main/apps/storage/ocis/app/helmrelease.yaml
@@ -113,14 +113,12 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host files.${CLUSTER_DOMAIN}
+          - host: files.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       storage-users:
         type: nfs

--- a/kubernetes/main/apps/storage/picoshare/app/helmrelease.yaml
+++ b/kubernetes/main/apps/storage/picoshare/app/helmrelease.yaml
@@ -67,14 +67,12 @@ spec:
           external-dns.alpha.kubernetes.io/target: external.${CLUSTER_DOMAIN}
           hajimari.io/icon: mdi:share-outline
         hosts:
-          - host: &host "share.${CLUSTER_DOMAIN}"
+          - host: "share.${CLUSTER_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       data:
         type: persistentVolumeClaim

--- a/kubernetes/main/apps/storage/syncthing/app/helmrelease.yaml
+++ b/kubernetes/main/apps/storage/syncthing/app/helmrelease.yaml
@@ -120,27 +120,23 @@ spec:
         annotations:
           hajimari.io/icon: "cloud"
         hosts:
-          - host: &host syncthing.${CLUSTER_DOMAIN}
+          - host: syncthing.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
       browser:
         className: internal
         annotations:
           hajimari.io/icon: mdi:folder-arrow-up-down-outline
         hosts:
-          - host: &host "sync.${CLUSTER_DOMAIN}"
+          - host: sync.${CLUSTER_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: browser
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       # TODO: volsync
       config:

--- a/kubernetes/main/apps/tools/clickops/app/helmrelease.yaml
+++ b/kubernetes/main/apps/tools/clickops/app/helmrelease.yaml
@@ -84,8 +84,6 @@ spec:
               service:
                 identifier: app
                 port: http
-        tls:
-          - hosts: [*host]
         annotations:
           hajimari.io/enable: "true"
           hajimari.io/icon: mouse

--- a/kubernetes/network/apps/default/blocky/app/helmrelease.yaml
+++ b/kubernetes/network/apps/default/blocky/app/helmrelease.yaml
@@ -104,15 +104,12 @@ spec:
       app:
         className: internal
         hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts:
-              - *host
     persistence:
       config:
         type: configMap

--- a/kubernetes/network/apps/default/emqx/cluster/ingress.yaml
+++ b/kubernetes/network/apps/default/emqx/cluster/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: internal
   rules:
-    - host: &host emqx.${SECRET_DOMAIN}
+    - host: emqx.${SECRET_DOMAIN}
       http:
         paths:
           - path: /
@@ -16,5 +16,3 @@ spec:
                 name: emqx-dashboard
                 port:
                   number: 18083
-  tls:
-    - hosts: [*host]

--- a/kubernetes/network/apps/external-secrets/external-secrets/stores/onepassword/helmrelease.yaml
+++ b/kubernetes/network/apps/external-secrets/external-secrets/stores/onepassword/helmrelease.yaml
@@ -126,14 +126,12 @@ spec:
         annotations:
           hajimari.io/enable: "false"
         hosts:
-          - host: &host "1pwconnect.${SECRET_DOMAIN}"
+          - host: 1pwconnect.${SECRET_DOMAIN}
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/network/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/network/apps/network/echo-server/app/helmrelease.yaml
@@ -78,11 +78,9 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/target: "network.${SECRET_DOMAIN}"
         hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-        tls:
-          - hosts: [*host]

--- a/kubernetes/network/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/network/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -105,9 +105,7 @@ spec:
         ingressClassName: internal
         pathType: Prefix
         hosts:
-          - &host prometheus-network.${SECRET_DOMAIN}
-        tls:
-          - hosts: [*host]
+          - prometheus-network.${SECRET_DOMAIN}
       prometheusSpec:
         podMetadata:
           annotations:

--- a/kubernetes/network/apps/storage/longhorn/app/helmrelease.yaml
+++ b/kubernetes/network/apps/storage/longhorn/app/helmrelease.yaml
@@ -55,7 +55,6 @@ spec:
       enabled: true
       ingressClassName: internal
       host: longhorn.${SECRET_DOMAIN}
-      tls: true
     longhornDriver:
       tolerations: &tolerations
         - key: CriticalAddonsOnly

--- a/kubernetes/registry/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/registry/apps/network/echo-server/app/helmrelease.yaml
@@ -71,11 +71,8 @@ spec:
         annotations:
           hajimari.io/icon: video-input-antenna
         hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
             paths:
               - path: /
                 service:
                   identifier: main
-        tls:
-          - hosts:
-              - *host


### PR DESCRIPTION
Remove tls blocks. HTTPS redirects are forced by nginx, and we have a wildcard certificate.